### PR TITLE
V3.0

### DIFF
--- a/X11rdp-o-matic.sh
+++ b/X11rdp-o-matic.sh
@@ -382,7 +382,7 @@ calc_cpu_cores()
 			let "MakesystemWorkHarder = $Cores + 1"
 			makeCommand="make -j $MakesystemWorkHarder"
 	else
-		PARALLELMAKE = 0
+		PARALLELMAKE=0
 	fi
 }
 


### PR DESCRIPTION
Quick fix to v3.0 for single-cpu systems. The patch to buildx.sh was being incorrectly applied in this case. I added extra checks so that this file would not be touched, for systems with only 1 CPU core. Sorry about that.
