### PR TITLE
Added "libtool-bin" to list of Required Packages (needed on recent Ubuntu)

### DIFF
--- a/X11rdp-o-matic.sh
+++ b/X11rdp-o-matic.sh
@@ -133,7 +133,7 @@ CONFIGUREFLAGS="--prefix=/usr --sysconfdir=/etc --localstatedir=/var --enable-fu
 
 # Declare a list of packages required to download sources/compile them...
 REQUIREDPACKAGES=(build-essential checkinstall automake automake1.9 git 
-git-core libssl-dev libpam0g-dev zlib1g-dev libtool libx11-dev libxfixes-dev 
+git-core libssl-dev libpam0g-dev zlib1g-dev libtool libtool-bin libx11-dev libxfixes-dev 
 pkg-config flex bison libxml2-dev intltool xsltproc xutils-dev python-libxml2 
 g++ xutils libfuse-dev wget libxrandr-dev x11proto-* libdrm-dev libpixman-1-dev 
 libgl1-mesa-dev libxkbfile-dev libxfont-dev libpciaccess-dev dh-make gettext 


### PR DESCRIPTION
libtool binary is no longer provided by libtool package, but libtool-bin.
Build tested and working on XUbuntu 15.04-beta2 (but systemd does not like xrdp init script).
