### PR TITLE
Change to withjpeg requiredpackages (Debian 8.x specific)

### DIFF
--- a/X11rdp-o-matic.sh
+++ b/X11rdp-o-matic.sh
@@ -279,7 +279,19 @@ case "$1" in
     ;;
     --withjpeg)
       CONFIGUREFLAGS+=(--enable-jpeg)
-      REQUIREDPACKAGES+=(libjpeg8-dev)
+      if [ -f /etc/debian_version ]; then
+    	VER=$(cat /etc/debian_version)
+	if [[ $VER == *"8."* ]]
+	then
+	  echo "Debian 8.x release detected, supplementing libjpeg8-dev with libjpeg62-turbo-dev"
+      	  REQUIREDPACKAGES+=(libjpeg62-turbo-dev)
+	else
+	  echo "Debian **non** 8.x release detected, using libjpeg8-dev"
+	  REQUIREDPACKAGES+=(libjpeg8-dev)
+	fi
+      else
+	REQUIREDPACKAGES+=(libjpeg8-dev)
+      fi
     ;;
     --withturbojpeg)
       CONFIGUREFLAGS+=(--enable-tjpeg)


### PR DESCRIPTION
Detect Debian 8.x release and supplement libjpeg8-dev (not available) with libjpeg62-turbo-dev due to error this was generating:

Package libjpeg8-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libjpeg62-turbo-dev
