### PR TITLE
Fixed grep for evaluating version of current xrdp git repository

### DIFF
--- a/X11rdp-o-matic.sh
+++ b/X11rdp-o-matic.sh
@@ -676,9 +676,9 @@ welcome_message()
 # Worked out from the chosen branch.
 calculate_version_num()
 {
-  README="https://raw.github.com/neutrinolabs/xrdp/$XRDPBRANCH/readme.txt"
+  README="https://raw.github.com/neutrinolabs/xrdp/$XRDPBRANCH/README.md"
   wget --no-check-certificate -O "$TMPFILE" "$README" >& /dev/null
-  VERSION=$(grep xrdp "$TMPFILE" | head -1 | cut -d " " -f2)
+  VERSION=$(grep -i version "$TMPFILE" | head -1 | cut -d " " -f3)
   rm -f "$TMPFILE"
   if [ "${XRDPBRANCH#v}" = "$XRDPBRANCH" ]
   then


### PR DESCRIPTION
New version of xrdp on github has a README.md not a readme.txt anymore